### PR TITLE
Add in options to give more control over connecting to S3, primarily to ...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,6 @@ test/integration/node_modules/**
 config/database.yml
 
 #this project
-config/initializers/aws.rb
 todo.txt
 
 #bower-controlled static assets

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
-source 'https://rails-assets.org'
+#source 'https://rails-assets.org'
 
-ruby '2.1.2'
+ruby '2.1.5'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.1.4'

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,9 @@ gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0',          group: :doc
 
+# seems required on Windows
+gem 'tzinfo-data'
+
 # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
 gem 'spring',        group: :development
 
@@ -62,5 +65,5 @@ gem 'will_paginate-bootstrap'
 
 gem 'leaflet-rails',          '0.7.4'
 gem 'passenger',              '4.0.53'
-gem 'mysql'
+#gem 'mysql'
 #gem 'pg',                     '0.17.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,7 +80,6 @@ GEM
     mini_portile (0.6.1)
     minitest (5.5.0)
     multi_json (1.10.1)
-    mysql (2.9.1)
     nokogiri (1.6.5)
       mini_portile (~> 0.6.0)
     open_id_authentication (1.2.0)
@@ -148,6 +147,8 @@ GEM
       coffee-rails
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    tzinfo-data (1.2015.1)
+      tzinfo (>= 1.0.0)
     uglifier (2.6.0)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
@@ -168,7 +169,6 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   leaflet-rails (= 0.7.4)
-  mysql
   open_id_authentication
   passenger (= 4.0.53)
   rails (= 4.1.4)
@@ -178,6 +178,7 @@ DEPENDENCIES
   spring
   sqlite3
   turbolinks
+  tzinfo-data
   uglifier (>= 1.3.0)
   will_paginate (~> 3.0.5)
   will_paginate-bootstrap

--- a/README.rdoc
+++ b/README.rdoc
@@ -20,8 +20,8 @@ Installing rvm for ruby management is recommended.
 
 MapMill 2 uses:
 
-* Ruby: 2.1.2
-* Rails: 4.1.4
+* Ruby: 2.1.5
+* Rails: 4.1.8
   * Mysql 2 (optional)
 
 The default `config/database.yml.sqlite3` uses SQLite.  Copy this to `config/database.yml` (and make changes to use MySQL if desired).
@@ -36,18 +36,6 @@ DO NOT CHECK IN THAT FILE INTO VERSION CONTROL, AS THIS WOULD SERIOUSLY COMPROMI
 
 
 
-== Windows Note
-
-For some Windows installations you will need to update SSL certificates.  You can do so by running the following commands:
-
-gem sources -r https://rubygems.org/
-gem sources -a http://rubygems.org/
-gem update --system
-gem sources -a https://rubygems.org/
-gem sources -r http://rubygems.org/
-
-
-
 == Running with local S3
 
 It is possible to run a local S3 (such as fakes3) so you do not need to connect to AWS.  This can be accomlished by adding the following lines to your `config/app_environment_vars.rb` file (example values provided):
@@ -58,7 +46,7 @@ ENV['S3_DEV_PORT']='10001'
 
 To install fakes3, run 'gem install fakes3'.
 
-You will also need to make '[bucketname].localhost' point to '127.0.0.1' (by editing yout hosts file, /etc/hosts or C:\Windows\System32\Drivers\etc\hosts).
+You will also need to make '[bucketname].localhost' point to '127.0.0.1' (by editing yout hosts file).
 
 To avoid problems with cross-domain errors, you'll need to disable these checks in your browser. If you are using Chrome, this can be done by running it with `google-chrome --disable-web-security`.
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -2,33 +2,48 @@
 
 MapMill 2 is a complete rewrite of MapMill -- an application developed during the BP oil spill, which enables large groups of people to sort through and rank very large image collections (1000s of images). 
 
-The new version now allows any user with a http://PublicLab.org user account to create new image sets and upload new images. To make this afforable to run, all image processing is performed on the client side and images are stored in AWS S3 cloud storage.
+The new version now allows any user with a http://PublicLab.org user account to create new image sets and upload new images. To make this affordable to run, all image processing is performed on the client side and images are stored in AWS S3 cloud storage.
 
-MapMill 2 uses the jquery-fileupload plugin to handle file uploads. See <a href="https://blueimp.github.io/jQuery-File-Upload/">https://blueimp.github.io/jQuery-File-Upload/</a>
+MapMill 2 uses the jquery-file-upload plugin to handle file uploads. See <a href="https://blueimp.github.io/jQuery-File-Upload/">https://blueimp.github.io/jQuery-File-Upload/</a>
 It also uses blueimp's gallery for as image gallery. See <a href="https://blueimp.github.io/Gallery/">https://blueimp.github.io/Gallery/</a>
 
 Thanks to Fabio Barone (http://publiclab.org/profile/faboolous) and Melissa Nunes (http://publiclab.org/profile/MelissaN) for their work on this new version of MapMill.
+
 
 == Installation
 
 Run `bundle install` to install the required gems.
 Run `bower install` to install the required static dependencies.
-The current version is configured with a mysql database.
+The current version is configured with a sqlite database.
 Installing rvm for ruby management is recommended.
 
 MapMill 2 uses:
 
 * Ruby: 2.1.2
 * Rails: 4.1.4
-* Mysql 2
+  * Mysql 2 (optional)
 
-Create a database first, create a user and grant privileges to that user. Then run rake db:migrate to run all needed migrations.
+The default `config/database.yml.sqlite3` uses SQLite.  Copy this to `config/database.yml` (and make changes to use MySQL if desired).
+
+Create a database first (rake db:create), create a user and grant privileges to that user. Then run rake db:migrate to run all needed migrations.
 
 In order to successfully configure AWS S3 stuff, edit the file `config/app_environment_vars.rb` file in the config directory, and add bucket name, AWS access key and secret as needed. A .sample file is provided in the same directory.
 
 DO NOT CHECK IN THAT FILE INTO VERSION CONTROL, AS THIS WOULD SERIOUSLY COMPROMISE SECURITY, MAKING YOUR KEYS ACCESSIBLE TO THE WORLD.
 
-/config/initializers/aws.rb contains needed initialization for AWS, which loads its values from the app_environment_vars.rb, but you should not need to edit this file.
+`config/initializers/aws.rb` contains needed initialization for AWS, which loads its values from the `app_environment_vars.rb`, but you should not need to edit this file.
+
+
+== Running with local S3
+
+It is possible to run a local S3 (such as fakes3) so you do not need to connect to AWS.  This can be accomlished by adding the following lines to your `config/app_environment_vars.rb` file (example values provided):
+
+ENV['S3_DEV_PROTOCOL']='http'
+ENV['S3_DEV_HOST']='localhost'
+ENV['S3_DEV_PORT']='10001'
+
+To avoid problems with cross-domain errors, you'll need to disable these checks in your browser. If you are using Chrome, this can be done by running it with `google-chrome --disable-web-security`.
+
 
 == Usage
 
@@ -46,11 +61,12 @@ The upload works like this:
 * Click the upload button
 * After images have been successfully uploaded, a thumbnail is automatically generated
 * As this is all CLIENT SIDE, this implies:
-  *  The client sends the image to AWS S3
+  * The client sends the image to AWS S3
   * If this went OK, a handle is returned. The client **saves the image on the server**
   * The server returns an id for the new image to the client; the client generates a thumbnail and **saves this thumbnail on AWS S3**
   * If this all went ok, the client associates the new thumbnail with the id of the image on the server
   * If that went ok, the process is finished
+
 
 == Contributors
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -10,9 +10,10 @@ It also uses blueimp's gallery for as image gallery. See <a href="https://blueim
 Thanks to Fabio Barone (http://publiclab.org/profile/faboolous) and Melissa Nunes (http://publiclab.org/profile/MelissaN) for their work on this new version of MapMill.
 
 
+
 == Installation
 
-Run `bundle install` to install the required gems.
+Run `bundle install` to install the required gems. (See 'Windows Note' if installing on Windows.)
 Run `bower install` to install the required static dependencies.
 The current version is configured with a sqlite database.
 Installing rvm for ruby management is recommended.
@@ -34,6 +35,19 @@ DO NOT CHECK IN THAT FILE INTO VERSION CONTROL, AS THIS WOULD SERIOUSLY COMPROMI
 `config/initializers/aws.rb` contains needed initialization for AWS, which loads its values from the `app_environment_vars.rb`, but you should not need to edit this file.
 
 
+
+== Windows Note
+
+For some Windows installations you will need to update SSL certificates.  You can do so by running the following commands:
+
+gem sources -r https://rubygems.org/
+gem sources -a http://rubygems.org/
+gem update --system
+gem sources -a https://rubygems.org/
+gem sources -r http://rubygems.org/
+
+
+
 == Running with local S3
 
 It is possible to run a local S3 (such as fakes3) so you do not need to connect to AWS.  This can be accomlished by adding the following lines to your `config/app_environment_vars.rb` file (example values provided):
@@ -42,7 +56,12 @@ ENV['S3_DEV_PROTOCOL']='http'
 ENV['S3_DEV_HOST']='localhost'
 ENV['S3_DEV_PORT']='10001'
 
+To install fakes3, run 'gem install fakes3'.
+
+You will also need to make '[bucketname].localhost' point to '127.0.0.1' (by editing yout hosts file, /etc/hosts or C:\Windows\System32\Drivers\etc\hosts).
+
 To avoid problems with cross-domain errors, you'll need to disable these checks in your browser. If you are using Chrome, this can be done by running it with `google-chrome --disable-web-security`.
+
 
 
 == Usage
@@ -66,6 +85,7 @@ The upload works like this:
   * The server returns an id for the new image to the client; the client generates a thumbnail and **saves this thumbnail on AWS S3**
   * If this all went ok, the client associates the new thumbnail with the id of the image on the server
   * If that went ok, the process is finished
+
 
 
 == Contributors

--- a/README.windows.rdoc
+++ b/README.windows.rdoc
@@ -1,0 +1,35 @@
+== Windows Notes
+
+This file contains some notes on getting MapMill up and running on Windows.
+
+
+
+== Installing Ruby/Rails
+
+You can use the Ruby 2.1 installer from this site:
+
+http://railsinstaller.org/ ->
+https://s3.amazonaws.com/railsinstaller/Windows/railsinstaller-3.1.0.exe
+
+
+For some Windows installations you will need to update SSL certificates after installing Ruby.  You can do so by running the following commands:
+
+gem sources -r https://rubygems.org/
+gem sources -a http://rubygems.org/
+gem update --system
+gem sources -a https://rubygems.org/
+gem sources -r http://rubygems.org/
+
+
+In order to get npm for installing bower, you can use this installer:
+
+http://nodejs.org/ ->
+http://nodejs.org/dist/v0.10.29/node-v0.10.29-x86.msi
+
+Note that newer versions (v0.10.36) encounter issues on Windows 8.1.
+
+
+
+== hosts File
+
+On Windows 7, the hosts file is at C:\Windows\System32\drivers\etc\hosts.

--- a/README.windows.rdoc
+++ b/README.windows.rdoc
@@ -11,6 +11,7 @@ You can use the Ruby 2.1 installer from this site:
 http://railsinstaller.org/ ->
 https://s3.amazonaws.com/railsinstaller/Windows/railsinstaller-3.1.0.exe
 
+You will want to install Git with this installer.
 
 For some Windows installations you will need to update SSL certificates after installing Ruby.  You can do so by running the following commands:
 
@@ -24,12 +25,18 @@ gem sources -r http://rubygems.org/
 In order to get npm for installing bower, you can use this installer:
 
 http://nodejs.org/ ->
-http://nodejs.org/dist/v0.10.29/node-v0.10.29-x86.msi
+http://nodejs.org/dist/v0.12.0/x64/node-v0.12.0-x64.msi
 
-Note that newer versions (v0.10.36) encounter issues on Windows 8.1.
+Note that other versions (ie v0.10.36) encounter issues on Windows 8.1.
+
+You may need to manually add "C:\Program Files\nodejs" to your PATH environment variable before running npm and bower:
+
+npm install -g bower
+
+You may also need to run your terminal as an administrator.
 
 
 
 == hosts File
 
-On Windows 7, the hosts file is at C:\Windows\System32\drivers\etc\hosts.
+On Windows, the hosts file is at C:\Windows\System32\drivers\etc\hosts.  Some folders may be hidden.

--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -103,8 +103,14 @@ class SitesController < ApplicationController
 
     # AWS S3 parameters which will be encoded in the jquery fileupload widget
     # This is important stuff as it is the security part allowing the upload to succeed
-    @s3_direct_post = S3_BUCKET.presigned_post(key: "uploads/#{SecureRandom.uuid}/${filename}", success_action_status: 201, acl: :public_read)
-    @s3_post_data = {url: @s3_direct_post.url, fields: @s3_direct_post.fields.to_json.html_safe, host: @s3_direct_post.url.host}
+    s3_secure = (S3_DEV_PROTOCOL != 'http')
+    @s3_direct_post = S3_BUCKET.presigned_post(key: "uploads/#{SecureRandom.uuid}/${filename}", success_action_status: 201, acl: :public_read, secure: s3_secure)
+    if S3_DEV_HOST
+      s3_url = S3_DEV_PROTOCOL + '://' + S3_BUCKET.name() + '.' + S3_DEV_HOST + ':' + S3_DEV_PORT + '/'
+    else
+      s3_url = @s3_direct_post.url
+    end
+    @s3_post_data = {url: s3_url, fields: @s3_direct_post.fields.to_json.html_safe, host: @s3_direct_post.url.host}
   end
 
   ##############################################################

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,0 +1,14 @@
+AWS.config(access_key_id: ENV['AWS_ACCESS_KEY_ID'], secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'])
+
+S3_DEV_PROTOCOL = ENV['S3_DEV_PROTOCOL']
+S3_DEV_HOST = ENV['S3_DEV_HOST']
+S3_DEV_PORT = ENV['S3_DEV_PORT']
+
+if S3_DEV_HOST
+  AWS.config(s3_endpoint: S3_DEV_HOST, s3_port: S3_DEV_PORT.to_i)
+  if S3_DEV_PROTOCOL == 'http'
+    AWS.config(use_ssl: false)
+  end
+end
+
+S3_BUCKET = AWS::S3.new.buckets[ENV['S3_BUCKET']]

--- a/config/initializers/aws.rb.sample
+++ b/config/initializers/aws.rb.sample
@@ -1,3 +1,0 @@
-AWS.config(access_key_id: ENV['AWS_ACCESS_KEY_ID'],
-secret_access_key: ENV['AWS_SECRET_ACCESS_KEY'] )
-S3_BUCKET = AWS::S3.new.buckets[ENV['S3_BUCKET']]


### PR DESCRIPTION
...allow connection to a local S3; update Gemfile and README.rdoc to reflect use of sqlite rather than mysql

This also included just moving aws.rb.sample to aws.rb. There might be a nicer way to handle the S3 configuration, but presigned_post seems to ignore the AWS config s3_port and use_ssl options.